### PR TITLE
Cache last entry inside birthday input

### DIFF
--- a/src/js/util/GetUserInput.js
+++ b/src/js/util/GetUserInput.js
@@ -82,6 +82,15 @@ function showBox() {
 
     arrowElement.removeEventListener('click', showBox);
     boxInput.addEventListener('input', dayCheck);
+
+    // If the user has already input the birthday, show it as default
+    if(localStorage.getItem('UserBirthDay')){
+        boxInput.value = localStorage.getItem('UserBirthDay');
+
+        // Manually trigger input event to check validity
+        const event = new Event('input');
+        boxInput.dispatchEvent(event);
+    }
 }
 
 /**
@@ -112,13 +121,25 @@ function handleKeyDownDay(event) {
         console.log(boxInput.value);
         // store birthday
         UserBirthDay = boxInput.value;
+        // cache in local storage
+        localStorage.setItem('UserBirthDay', UserBirthDay);
         let curDialogue = document.querySelector('.dialogue-text');
         curDialogue.textContent = 'Curious! Now, what month were you born? (enter to proceed)';
+
         boxInput.removeEventListener('input', dayCheck);
         boxInput.removeEventListener('keydown', handleKeyDownDay);
         boxInput.value = '';
         boxInput.placeholder = 'mm';
         boxInput.addEventListener('input', monthCheck);
+
+        // If the user has already input the birthday, show it as default
+        if(localStorage.getItem('UserBirthMonth')){
+            boxInput.value = localStorage.getItem('UserBirthMonth');
+
+            // Manually trigger input event to check validity
+            const event = new Event('input');
+            boxInput.dispatchEvent(event);
+        }
     }
 }
 
@@ -152,13 +173,25 @@ function handleKeyDownMonth(event) {
         console.log(boxInput.value);
         // store birth month
         UserBirthMonth = boxInput.value;
+        // cache in local storage
+        localStorage.setItem('UserBirthMonth', UserBirthMonth);
         let curDialogue = document.querySelector('.dialogue-text');
         curDialogue.textContent = 'Oh! Do tell me the year you were born (enter to proceed)';
+
         boxInput.removeEventListener('input', monthCheck);
         boxInput.removeEventListener('keydown', handleKeyDownMonth);
         boxInput.value = '';
         boxInput.placeholder = 'yyyy';
         boxInput.addEventListener('input', yearCheck);
+
+        // If the user has already input the birthday, show it as default
+        if(localStorage.getItem('UserBirthYear')) {
+            boxInput.value = localStorage.getItem('UserBirthYear');
+
+            // Manually trigger input event to check validity
+            const event = new Event('input');
+            boxInput.dispatchEvent(event);
+        }
     }
 }
 
@@ -192,6 +225,8 @@ function handleKeyDownYear(event) {
         console.log(boxInput.value);
         // store birth year
         UserBirthYear = boxInput.value;
+        // cache in local storage
+        localStorage.setItem('UserBirthYear', UserBirthYear);
         let curDialogue = document.querySelector('.dialogue-text');
         curDialogue.textContent = 'Finally, tell me what your current mood is';
         boxInput.removeEventListener('input', yearCheck);


### PR DESCRIPTION
# Overview
One annoying thing I ran into while using the website is whenever you get a new fortune, you need to reenter your birthday every time. Since we want to be able to enter different birthdays, for example, if another user tries on the same user's computer, but in most cases the birthday will be the same, the best solution is to autofill the last entered birthday so the user can just press enter if they want to keep the birthday the same.

# Changes
This PR stores the last entered birth day, month, and year inside local storage keys `UserBirthDay`, `UserBirthMonth`, `UserBirthYear`, respectively. When the form loads again, it will check if these keys exist in localstorage and if so, manually set the inputValue to what is stored. It will then manually trigger an input event to validate the form.

# Testing
This has been tested myself, but all you need to do to test is enter in your birthday as normal then run through the form again and see if the last birthday is autofilled.